### PR TITLE
Save and display authenticator transports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
         "node_modules{,/**}",
         ".vscode{,/**}",
         ".env"
-    ]
+    ],
+    "files.insertFinalNewline": false
 }

--- a/fido.js
+++ b/fido.js
@@ -100,6 +100,7 @@ fido.makeCredential = async (uid, attestation) => {
         uid: uid,
         id: authenticatorData.attestedCredentialData.credentialId.toString('base64'),
         idHex: authenticatorData.attestedCredentialData.credentialId.toString('hex').toUpperCase(),
+        transports: attestation.transports,
         metadata: {
             rpId: defaultTo(attestation.metadata.rpId, hostname),
             userName: attestation.metadata.userName,

--- a/public/index.js
+++ b/public/index.js
@@ -374,6 +374,7 @@
                 id: base64encode(attestation.rawId),
                 clientDataJSON: arrayBufferToString(attestation.response.clientDataJSON),
                 attestationObject: base64encode(attestation.response.attestationObject),
+                transports: attestation.response.getTransports(),
                 metadata: {
                     rpId: createCredentialOptions.rp.id,
                     userName: createCredentialOptions.user.name,
@@ -590,6 +591,7 @@
         html += '         <br>Key Type: ' + credential.creationData.publicKeySummary;
         html += '         <br>Discoverable Credential: ' + credential.metadata.residentKey;
         html += '         <br>Attestation Type: ' + credential.creationData.attestationStatementSummary;
+        html += '         <br>Transports: [' + credential.transports.join(', ') + ']';
         html += '         <br>' + credential.creationData.authenticatorDataSummary;
         html += '     </p>';
         html += '     <p>';

--- a/public/types.js
+++ b/public/types.js
@@ -31,6 +31,7 @@
  * @property {string} metadata.userName user.name assigned to this credenital
  * @property {string} metadata.rpId rp.id assigned to this credential
  * @property {boolean} metadata.residentKey whether this is a resident key
+ * @property {Array<string>} metadata.transports
  * @property {Object} creationData
  * @property {Object} creationData.publicKey JWK represetation of cred public key
  * @property {string} creationData.publicKeySummary human readable summary of credential public key

--- a/storage.js
+++ b/storage.js
@@ -10,6 +10,7 @@ storage.Credentials = mongoose.model('Credential', new mongoose.Schema({
     uid: {type: String, index: true},
     id: {type: String, index: true},
     idHex: String,
+    transports: [{type: String}],
     metadata: {
         rpId: String,
         userName: String,


### PR DESCRIPTION
Add the ability for WebAuthnTest to save and display which transports the authenticator reports to support.

![image](https://github.com/microsoft/webauthntest/assets/2382974/3ea3f91f-7b50-4d36-a854-0dedb34f01b5)

* The first credential was created before this support was added, showing what existing credentials in production will look like after this is merged.
* The second one was created after this support was added, and within my Hello container.
* The third one was also created within my Hello container, but I edited the transport list before it was published to the server just so we could see what multiple transports would look like.

I don't know exactly the desired structure of the Credential objects, so I'm happy to move the transports field under "metadata" or another field if it would be better there.

This doesn't add support for using the transports as a part of GetAssertion requests, but is a first step towards that.

Also, I am a Javascript NOOB so keep that in mind when reviewing :).