### PR TITLE
Add check for if transports property exists

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -591,7 +591,9 @@
         html += '         <br>Key Type: ' + credential.creationData.publicKeySummary;
         html += '         <br>Discoverable Credential: ' + credential.metadata.residentKey;
         html += '         <br>Attestation Type: ' + credential.creationData.attestationStatementSummary;
-        html += '         <br>Transports: [' + credential.transports.join(', ') + ']';
+        if (credential.hasOwnProperty('transports')) {
+            html += '         <br>Transports: [' + credential.transports.join(', ') + ']';
+        }
         html += '         <br>' + credential.creationData.authenticatorDataSummary;
         html += '     </p>';
         html += '     <p>';


### PR DESCRIPTION
This should stop the crash happening on the site for now while we figure out if we need to do a data migration or something.